### PR TITLE
DOPS-1722: Create CI for iroha2-load-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iroha_client = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "=2.0.0-pre-rc.3" }
-iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "=2.0.0-pre-rc.3" }
+iroha_client = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2-dev", version = "=2.0.0-pre-rc.3" }
+iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2-dev", version = "=2.0.0-pre-rc.3" }
 rouille = "3.5.0"
 serde_json = "1.0.73"
 serde = "1.0.132"


### PR DESCRIPTION
# Task

[DOPS-1722]:  Create CI for iroha2-load-rs script

## Changes

1. add workflow for iroha2 longevity load-rs `dev` branch

## Author

Signed-off-by: <vzyabkin@soramitsu.co.jp>


[DOPS-1722]: https://soramitsu.atlassian.net/browse/DOPS-1722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ