### PR TITLE
SUP-945: iroha2-longevity-load-rs container restarting

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,22 @@
+version: 2
+
+updates:
+  # Maintain docker dependencies
+  - package-ecosystem: "docker"
+    schedule:
+      interval: "weekly"
+    target-branch: "master"
+    directory: "/"
+
+  # Maintain cargo dependencies
+  - package-ecosystem: "cargo"
+    schedule:
+      interval: "daily"
+    target-branch: "dev"
+    directory: "/"
+
+  - package-ecosystem: "cargo"
+    schedule:
+      interval: "daily"
+    target-branch: "release"
+    directory: "/"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,23 +4,23 @@ COPY src src
 COPY Cargo.toml Cargo.toml
 COPY config.json config.json
 
-RUN sudo chown -R rust:rust /home/rust && \
-    cargo build --release
+RUN cargo build --release
 
 
 FROM alpine:3.16
 
 ENV LOAD_DIR=/opt/iroha2_load_rs
 
-RUN mkdir ${LOAD_DIR} && \
+RUN mkdir -p ${LOAD_DIR} && \
     apk --no-cache add ca-certificates && \
-    adduser --disabled-password --gecos "" iroha && \
-    chown -R iroha ${LOAD_DIR}
-    
-USER iroha
+    adduser --disabled-password --gecos "" iroha
 
 WORKDIR ${LOAD_DIR}
-
+    
 COPY --from=builder \
-    /home/rust/src/target/x86_64-unknown-linux-musl/release/iroha2-longevity-load-rs \
-    ${LOAD_DIR}
+     /home/rust/src/target/x86_64-unknown-linux-musl/release/iroha2-longevity-load-rs \
+     ${LOAD_DIR}
+
+USER iroha
+
+ENV PORT 8084

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,18 +9,18 @@ RUN cargo build --release
 
 FROM alpine:3.16
 
+ENV PORT=8084
+
 ENV LOAD_DIR=/opt/iroha2_load_rs
 
-RUN mkdir -p ${LOAD_DIR} && \
-    apk --no-cache add ca-certificates && \
-    adduser --disabled-password --gecos "" iroha
+RUN set -ex && \
+    apk --update --no-cache add ca-certificates && \
+    adduser --disabled-password --gecos "" iroha --shell /bin/bash --home /app && \
+    mkdir -p ${LOAD_DIR}
 
 WORKDIR ${LOAD_DIR}
-    
+
 COPY --from=builder \
-     /home/rust/src/target/x86_64-unknown-linux-musl/release/iroha2-longevity-load-rs \
-     ${LOAD_DIR}
+     /home/rust/src/target/x86_64-unknown-linux-musl/release/iroha2-longevity-load-rs .
 
 USER iroha
-
-ENV PORT 8084

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ ENV PORT=8084
 
 ENV LOAD_DIR=/opt/iroha2_load_rs
 
-RUN set -ex && \
-    apk --update --no-cache add ca-certificates && \
+RUN apk --update --no-cache add ca-certificates && \
     adduser --disabled-password --gecos "" iroha --shell /bin/bash --home /app && \
     mkdir -p ${LOAD_DIR}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,26 @@
-FROM rust:1.60
-
-ENV LOAD_DIR=/opt/iroha2_load_rs
-
-RUN mkdir ${LOAD_DIR}
-
-WORKDIR ${LOAD_DIR}
+FROM nwtgck/rust-musl-builder:1.60.0 as builder
 
 COPY src src
 COPY Cargo.toml Cargo.toml
 COPY config.json config.json
 
-RUN adduser --disabled-password --gecos "" iroha && \
-   chown -R iroha ${LOAD_DIR}
+RUN sudo chown -R rust:rust /home/rust && \
+    cargo build --release
 
+
+FROM alpine:3.16
+
+ENV LOAD_DIR=/opt/iroha2_load_rs
+
+RUN mkdir ${LOAD_DIR} && \
+    apk --no-cache add ca-certificates && \
+    adduser --disabled-password --gecos "" iroha && \
+    chown -R iroha ${LOAD_DIR}
+    
 USER iroha
 
-CMD ["cargo", "run"]
+WORKDIR ${LOAD_DIR}
+
+COPY --from=builder \
+    /home/rust/src/target/x86_64-unknown-linux-musl/release/iroha2-longevity-load-rs \
+    ${LOAD_DIR}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It was mainly created to test longevity stand for Iroha2.
 
 ### Prerequisites
 
-1. Rust 1.57.0 ([Installation guide](https://www.rust-lang.org/tools/install))
+1. Rust 1.60.0 ([Installation guide](https://www.rust-lang.org/tools/install))
 2. Edit `config.json` depending on your setup
 3. Network should be started and have committed a genesis block
 4. Have the Iroha repository locally.


### PR DESCRIPTION
# Task

[SUP-945]: docker_restarting_container stage1 iroha2, instance: iroha2-stage1-s5

## Changes

1. add docker multistage build to compile RUST binary inside image.
2. add raw `dependabot.yaml` in order to test its work in the upcoming release

## Author

Signed-off-by: Vasilii Zyabkin <zyabkin@soramitsu.co.jp>


[SUP-945]: https://soramitsu.atlassian.net/browse/SUP-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ