### PR TITLE
DOPS-1683: Check iroha2 dependencies in Cargo.toml

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -48,5 +48,5 @@ jobs:
           assignee: ${{ github.actor }}
           reviewer: 2694109
           label: iroha2,longevity
-          target_branch: release
+          get_diff: true
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,0 +1,47 @@
+name: load-rs::bump-dependencies
+#on: [push, pull_request]
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+
+# on:
+#   workflow_dispatch:
+
+env:
+  VERSION_URL: 'https://raw.githubusercontent.com/hyperledger/iroha/iroha2/data_model/Cargo.toml'
+
+jobs:
+  bump-iroha2-dev:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Grep iroha2 version from hyperledger repository
+        uses: mathiasvr/command-output@v1
+        id: new_version
+        with:
+          run: curl -s ${{ env.VERSION_URL }} | sed -ne '3p' | tr -d '\n'
+      - name: Find and Replace
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: version = "2.0.0-pre-rc.*
+          replace: "${{ steps.new_version.outputs.stdout }}"
+          include: "Cargo.toml"
+          regex: true
+      - name: Push changes
+        uses: devops-infra/action-commit-push@v0.9.0
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          add_timestamp: true
+          commit_message: "bump iroha2 versions in Cargo.toml"
+          target_branch: bump-iroha2-version
+      - name: Create pull request
+        uses: devops-infra/action-pull-request@v0.5.0
+        with:
+          title: "Update iroha2 dependencies to ${{ steps.new_version.outputs.stdout }}"
+          body: "**Automated pull request**<br><br><p>Update `iroha client` and `iroha_data_model` dependencies from <a href=${{ env.VERSION_URL }}>Hyperledger repository</a></p>"
+          assignee: ${{ github.actor }}
+          reviewer: BAStos525
+          label: iroha2,longevity
+        #  target_branch: release
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -27,14 +27,14 @@ jobs:
       - name: Find and replace 3th line
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          find: version = "2.0.0-pre-rc.*"
+          find: version = ".*-pre-rc.*"
           replace: "${{ steps.new_version.outputs.stdout }}"
           include: "Cargo.toml"
           regex: true
       - name: Find and replace 9-10th lines
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          find: version = "2.0.0-pre-rc.*" }
+          find: version = ".*-pre-rc.*" }
           replace: "${{ steps.new_version.outputs.stdout }} }"
           include: "Cargo.toml"
           regex: true

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -8,7 +8,7 @@ on:
   schedule:
     - cron: '0 10 * * 1,5'
 
-# TODO: switch to workflow `dispatch` trigger and move workflows to dev and release branches
+# TODO: try to switch to workflow `dispatch` trigger and move workflows to dev and release branches
 #       in the future when iroha2-dev team will agree with it
 
 env:
@@ -27,15 +27,15 @@ jobs:
       - name: Find and replace 3th line
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          find: version = "2.0.0-pre-rc.*
+          find: version = "2.0.0-pre-rc.*"
           replace: "${{ steps.new_version.outputs.stdout }}"
           include: "Cargo.toml"
           regex: true
       - name: Find and replace 9-10th lines
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          find: ', version = "2.0.0-pre-rc.*'
-          replace: ", ${{ steps.new_version.outputs.stdout }} }"
+          find: version = "2.0.0-pre-rc.*" }
+          replace: "${{ steps.new_version.outputs.stdout }} }"
           include: "Cargo.toml"
           regex: true
       - name: Push changes

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -23,21 +23,25 @@ jobs:
         uses: mathiasvr/command-output@v1
         id: new_version
         with:
-          run: curl -s ${{ env.VERSION_URL }} | sed -ne '3p' | tr -d '\n'
-      - name: Find and replace 3th line
-        uses: jacobtomlinson/gha-find-replace@v2
+          run: curl -s ${{ env.VERSION_URL }} | sed -n '3p' | sed -e 's/version = "//g' -e 's/"$//' | tr -d '\n'
+      - name: Edit package.version key
+        uses: ciiiii/toml-editor@1.0.0
         with:
-          find: version = "2.*.*"
-          replace: "${{ steps.new_version.outputs.stdout }}"
-          include: "Cargo.toml"
-          regex: true
-      - name: Find and replace 9-10th lines
-        uses: jacobtomlinson/gha-find-replace@v2
+          file: "Cargo.toml"
+          key: "package.version"
+          value: ${{ steps.new_version.outputs.stdout }}
+      - name: Edit iroha_client.version key
+        uses: ciiiii/toml-editor@1.0.0
         with:
-          find: version = "2.*.*" }
-          replace: "${{ steps.new_version.outputs.stdout }} }"
-          include: "Cargo.toml"
-          regex: true
+          file: "Cargo.toml"
+          key: "dependencies.iroha_client.version"
+          value: ${{ steps.new_version.outputs.stdout }} 
+      - name: Edit iroha_data_model key
+        uses: ciiiii/toml-editor@1.0.0
+        with:
+          file: "Cargo.toml"
+          key: "dependencies.iroha_data_model.version"
+          value: ${{ steps.new_version.outputs.stdout }}
       - name: Push changes
         uses: devops-infra/action-commit-push@v0.9.0
         with:

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -27,14 +27,14 @@ jobs:
       - name: Find and replace 3th line
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          find: version = ".*-pre-rc.*"
+          find: version = "2.*.*"
           replace: "${{ steps.new_version.outputs.stdout }}"
           include: "Cargo.toml"
           regex: true
       - name: Find and replace 9-10th lines
         uses: jacobtomlinson/gha-find-replace@v2
         with:
-          find: version = ".*-pre-rc.*" }
+          find: version = "2.*.*" }
           replace: "${{ steps.new_version.outputs.stdout }} }"
           include: "Cargo.toml"
           regex: true

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,17 +1,15 @@
 name: load-rs::bump-dependencies
 
-on:
-  push
-
 # Currently these dependencies are updated once per 1-2 months
 #   but there is not an any established day to update them
-# Run workflow At 10:00 UTC on Monday and Friday every week 
-# on:
-#   schedule:
-#     - cron: '0 10 * * 1,5'
+# Workflow on `schedule` trigger could be run only on master/base branch
+# Run workflow At 10:00 UTC on Monday and Friday every week
+on:
+  schedule:
+    - cron: '0 10 * * 1,5'
 
-# TODO: switch to workflow `dispatch` trigger
-#   in the future when iroha2-dev team will agree with it
+# TODO: switch to workflow `dispatch` trigger and move workflows to dev and release branches
+#       in the future when iroha2-dev team will agree with it
 
 env:
   VERSION_URL: 'https://raw.githubusercontent.com/hyperledger/iroha/iroha2/data_model/Cargo.toml'
@@ -20,17 +18,24 @@ jobs:
   bump-load-rs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Grep iroha2 version from hyperledger repository
+      - uses: actions/checkout@v3
+      - name: Get iroha2 version from hyperledger repository
         uses: mathiasvr/command-output@v1
         id: new_version
         with:
           run: curl -s ${{ env.VERSION_URL }} | sed -ne '3p' | tr -d '\n'
-      - name: Find and Replace
+      - name: Find and replace 3th line
         uses: jacobtomlinson/gha-find-replace@v2
         with:
           find: version = "2.0.0-pre-rc.*
           replace: "${{ steps.new_version.outputs.stdout }}"
+          include: "Cargo.toml"
+          regex: true
+      - name: Find and replace 9-10th lines
+        uses: jacobtomlinson/gha-find-replace@v2
+        with:
+          find: ', version = "2.0.0-pre-rc.*'
+          replace: ", ${{ steps.new_version.outputs.stdout }} }"
           include: "Cargo.toml"
           regex: true
       - name: Push changes
@@ -40,13 +45,20 @@ jobs:
           add_timestamp: true
           commit_message: "bump iroha2 versions in Cargo.toml"
           target_branch: bump-iroha2-version
-      - name: Create pull request
-        uses: devops-infra/action-pull-request@v0.5.0
+      - name: Get PR branch name
+        uses: mathiasvr/command-output@v1
+        id: pr_branch
         with:
-          title: "Update iroha2 dependencies to ${{ steps.new_version.outputs.stdout }}"
-          body: "**Automated pull request**<br><br><p>Update `iroha client` and `iroha_data_model` dependencies from <a href=${{ env.VERSION_URL }}>Hyperledger repository</a></p>"
-          assignee: ${{ github.actor }}
-          reviewer: 2694109
-          label: iroha2,longevity
-          get_diff: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run: git symbolic-ref --short HEAD | tr -d '\n'
+      - name: Create pull request
+        uses: vsoch/pull-request-action@1.0.19
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST_BRANCH: "master"
+          PULL_REQUEST_FROM_BRANCH: "${{ steps.pr_branch.outputs.stdout }}"
+          PULL_REQUEST_TITLE: "Update iroha2 dependencies to ${{ steps.new_version.outputs.stdout }}"
+          PULL_REQUEST_BODY: "**Automated pull request**<br><br><p>Update `iroha client` and `iroha_data_model` dependencies from <a href=${{ env.VERSION_URL }}>Hyperledger repository</a></p>"
+          PULL_REQUEST_ASSIGNEES: ${{ github.actor }}
+          PULL_REQUEST_REVIEWERS: BAStos525
+          PULL_REQUEST_TEAM_REVIEWERS: soramitsu/devops-team soramitsu/devops-support
+          PULL_REQUEST_UPDATE: true

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,18 +1,23 @@
 name: load-rs::bump-dependencies
-#on: [push, pull_request]
 
 on:
-  schedule:
-    - cron: '*/15 * * * *'
+  push
 
+# Currently these dependencies are updated once per 1-2 months
+#   but there is not an any established day to update them
+# Run workflow At 10:00 UTC on Monday and Friday every week 
 # on:
-#   workflow_dispatch:
+#   schedule:
+#     - cron: '0 10 * * 1,5'
+
+# TODO: switch to workflow `dispatch` trigger
+#   in the future when iroha2-dev team will agree with it
 
 env:
   VERSION_URL: 'https://raw.githubusercontent.com/hyperledger/iroha/iroha2/data_model/Cargo.toml'
 
 jobs:
-  bump-iroha2-dev:
+  bump-load-rs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -41,7 +46,7 @@ jobs:
           title: "Update iroha2 dependencies to ${{ steps.new_version.outputs.stdout }}"
           body: "**Automated pull request**<br><br><p>Update `iroha client` and `iroha_data_model` dependencies from <a href=${{ env.VERSION_URL }}>Hyperledger repository</a></p>"
           assignee: ${{ github.actor }}
-          reviewer: BAStos525
+          reviewer: 2694109
           label: iroha2,longevity
-        #  target_branch: release
+          target_branch: release
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iroha_client = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "=2.0.0-pre-rc.5" }
-iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "=2.0.0-pre-rc.5" }
+iroha_client = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "2.0.0-pre-rc.5" }
+iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "2.0.0-pre-rc.5" }
 rouille = "3.5.0"
 serde_json = "1.0.73"
 serde = "1.0.132"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "iroha2-longevity-load-rs"
-version = "2.0.0-pre-rc.6"
+version = "2.0.0-pre-rc.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iroha_client = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "=2.0.0-pre-rc.6" }
-iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "=2.0.0-pre-rc.6" }
+iroha_client = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "=2.0.0-pre-rc.5" }
+iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "=2.0.0-pre-rc.5" }
 rouille = "3.5.0"
 serde_json = "1.0.73"
 serde = "1.0.132"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "iroha2-longevity-load-rs"
-version = "2.0.0-pre-rc.5"
+version = "2.0.0-pre-rc.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iroha_client = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "2.0.0-pre-rc.5" }
-iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "2.0.0-pre-rc.5" }
+iroha_client = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "2.0.0-pre-rc.6" }
+iroha_data_model = { git = "https://github.com/hyperledger/iroha.git", branch = "iroha2", version = "2.0.0-pre-rc.6" }
 rouille = "3.5.0"
 serde_json = "1.0.73"
 serde = "1.0.132"


### PR DESCRIPTION
# Task

[DOPS-1683]:  Implement iroha2 longevity script dependencies auto checking from hyperledger repository.

## Issue
Currently we added dependabot for. But dependencies for `iroha_clienta` and `iroha_data_model` can not be checked by dependabot. Every time developers have to update it manually and they often forget to do it in time.

## Changes

1. Add GH Action workflow to check for a new `iroha_data_model` and `iroha_client` versions from root Hyperledger repository and create a PR then.

## Possible improvements
It is better to make this workflow on `dispatch` event and move to `dev` and `release` branches. But firstly we need to take an agreement with iroha2-dev team about new changes in their Hyperledger CI. Perhaps, we will do it in [DOPS-1682](https://soramitsu.atlassian.net/jira/software/c/projects/DOPS/boards/43?modal=detail&selectedIssue=DOPS-1862&assignee=611c97b0a3e00f006875887b)

## Author

Signed-off-by: Vasilii Zyabkin <vzyabkin@soramitsu.co.jp>


[DOPS-1683]: https://soramitsu.atlassian.net/browse/DOPS-1683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ