### PR TITLE
DOPS-1897: Improve iroha2 load-rs CI automation

### DIFF
--- a/.github/workflows/load-rs-push-from-dev.yaml
+++ b/.github/workflows/load-rs-push-from-dev.yaml
@@ -22,7 +22,7 @@ jobs:
           context: .
           push: true
           tags: soramitsu/iroha2-longevity-load-rs:dev   
-      - name: Synchronize with iroha2:dev repo
+      - name: Synchronize with hyperledger/iroha2:dev repo
         run: |
           echo "response about the workflow end"
           sleep 10s

--- a/.github/workflows/sync-branches.yaml
+++ b/.github/workflows/sync-branches.yaml
@@ -1,0 +1,40 @@
+name: load-rs::sync branches
+
+# The goal of this workflow is to create PR with changes of load-rs script itself
+#   from iroha2-dev branch because we need to keep the same rust source code for all script versions
+# Ignore changes to Cargo.toml since this file should be updated from load-rs::bump-dependencies workflow
+# No need to touch iroha2-lts branch because it is updated once per six months and should be stable
+
+on:
+ pull_request:
+  branches: [iroha2-dev]
+  types: [closed]
+
+jobs:
+  merge_iroha2-dev_to_master:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+      - name: Filter files to be merged
+        uses: dorny/paths-filter@v2.10.2
+        id: filter
+        with:
+          base: master
+          filters: |
+            cargo:
+              - 'Cargo.toml'
+      - name: Create pull request
+        if: steps.filter.outputs.cargo == 'false'
+        uses: vsoch/pull-request-action@1.0.19
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_REQUEST_BRANCH: "master"
+          PULL_REQUEST_FROM_BRANCH: "iroha2-dev"
+          PULL_REQUEST_TITLE: "Merge master into iroha2-dev"
+          PULL_REQUEST_BODY: "**Automated pull request**<br><br><p>Synchronize a changes from iroha2-dev to master branches</p>"
+          PULL_REQUEST_ASSIGNEES: ${{ github.actor }}
+          PULL_REQUEST_REVIEWERS: BAStos525
+          PULL_REQUEST_TEAM_REVIEWERS: soramitsu/devops-team soramitsu/devops-support
+          PULL_REQUEST_UPDATE: true

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -2,21 +2,21 @@ name: load-rs::bump-dependencies
 
 # Currently these dependencies are updated once per 1-2 months
 #   but there is not an any established day to update them
-# Workflow on `schedule` trigger could be run only on master/base branch
-# Run workflow At 10:00 UTC on Monday and Friday every week
-on:
-  schedule:
-    - cron: '0 10 * * 1,5'
+# This is a dispatch event workflow that triggered 
+#   from I2::Dev::Deploy workflow in Hyperledger repo,
+#   merge changes to iroha2-dev branch and create a PR to master
 
-# TODO: try to switch to workflow `dispatch` trigger and move workflows to dev and release branches
-#       in the future when iroha2-dev team will agree with it
+on:
+   workflow_dispatch: 
 
 env:
-  VERSION_URL: 'https://raw.githubusercontent.com/hyperledger/iroha/iroha2/data_model/Cargo.toml'
+  VERSION_URL: 'https://raw.githubusercontent.com/hyperledger/iroha/iroha2-dev/data_model/Cargo.toml'
 
 jobs:
-  bump-load-rs:
+  merge-load-rs-iroha2-dev:
     runs-on: ubuntu-latest
+    outputs:
+      pr_title: ${{ steps.new_version.outputs.stdout }}
     steps:
       - uses: actions/checkout@v3
       - name: Get iroha2 version from hyperledger repository
@@ -42,26 +42,31 @@ jobs:
           file: "Cargo.toml"
           key: "dependencies.iroha_data_model.version"
           value: ${{ steps.new_version.outputs.stdout }}
+      - name: Edit iroha_config key
+        uses: ciiiii/toml-editor@1.0.0
+        with:
+          file: "Cargo.toml"
+          key: "dependencies.iroha_config.version"
+          value: ${{ steps.new_version.outputs.stdout }}          
       - name: Push changes
         uses: devops-infra/action-commit-push@v0.9.0
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
-          add_timestamp: true
           commit_message: "bump iroha2 versions in Cargo.toml"
-          target_branch: bump-iroha2-version
-      - name: Get PR branch name
-        uses: mathiasvr/command-output@v1
-        id: pr_branch
-        with:
-          run: git symbolic-ref --short HEAD | tr -d '\n'
+
+  bump-load-rs-master:
+    needs: [merge-load-rs-iroha2-dev]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
       - name: Create pull request
         uses: vsoch/pull-request-action@1.0.19
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PULL_REQUEST_BRANCH: "master"
-          PULL_REQUEST_FROM_BRANCH: "${{ steps.pr_branch.outputs.stdout }}"
-          PULL_REQUEST_TITLE: "Update iroha2 dependencies to ${{ steps.new_version.outputs.stdout }}"
-          PULL_REQUEST_BODY: "**Automated pull request**<br><br><p>Update `iroha client` and `iroha_data_model` dependencies from <a href=${{ env.VERSION_URL }}>Hyperledger repository</a></p>"
+          PULL_REQUEST_FROM_BRANCH: "iroha2-dev"
+          PULL_REQUEST_TITLE: "Update iroha2 dependencies to ${{ needs.merge-load-rs-iroha2-dev.outputs.pr_title }}"
+          PULL_REQUEST_BODY: "**Automated pull request**<br><br><p>Update iroha2 dependencies from <a href=${{ env.VERSION_URL }}>Hyperledger repository</a></p>"
           PULL_REQUEST_ASSIGNEES: ${{ github.actor }}
           PULL_REQUEST_REVIEWERS: BAStos525
           PULL_REQUEST_TEAM_REVIEWERS: soramitsu/devops-team soramitsu/devops-support

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -53,6 +53,10 @@ jobs:
         with:
           github_token: "${{ secrets.GITHUB_TOKEN }}"
           commit_message: "bump iroha2 versions in Cargo.toml"
+      - name: Synchronize with hyperledger/iroha2:dev repo
+        run: |
+          echo "response about the workflow end"
+          sleep 10s
 
   bump-load-rs-master:
     needs: [merge-load-rs-iroha2-dev]

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -7,7 +7,7 @@ name: load-rs::bump-dependencies
 #   merge changes to iroha2-dev branch and create a PR to master
 
 on:
-   workflow_dispatch: 
+   workflow_dispatch:
 
 env:
   VERSION_URL: 'https://raw.githubusercontent.com/hyperledger/iroha/iroha2-dev/data_model/Cargo.toml'
@@ -35,7 +35,7 @@ jobs:
         with:
           file: "Cargo.toml"
           key: "dependencies.iroha_client.version"
-          value: ${{ steps.new_version.outputs.stdout }} 
+          value: ${{ steps.new_version.outputs.stdout }}
       - name: Edit iroha_data_model key
         uses: ciiiii/toml-editor@1.0.0
         with:


### PR DESCRIPTION
# Task

[DOPS-1897]: Fix and improve the CI of iroha2 longevity script.

## Changes
*All changes were discussed and confirmed with iroha2 team*.

1. Add a new dependencies key.
2. Switch to `dispatch` event workflow trigger from Hyperleger repository.
3. Automatically merge dependencies changes to `iroha2-dev` branch otherwise `I2::Dev::Deploy` workflow might be failed during its execution on the step of longevity script compilation.
4. After that call job to create a PR with dependencies changes to `master` branch.
5. Add `sync-branches` workflow to create PR from iroha2-dev to master branch with a fresh changes except `Cargo.toml`.
6. No need to pay attention to `iroha2-lts` branch because it's updated once per six months.

## Author

Signed-off-by: Vasilii Zyabkin <zyabkin@soramitsu.co.jp>


[DOPS-1897]: https://soramitsu.atlassian.net/browse/DOPS-1897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ