### PR TITLE
[ci] soramitsu#27: Rename branch `master` to `iroha2-stable`

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,18 +5,12 @@ updates:
   - package-ecosystem: "docker"
     schedule:
       interval: "weekly"
-    target-branch: "master"
+    target-branch: "iroha2-stable"
     directory: "/"
 
   # Maintain cargo dependencies
   - package-ecosystem: "cargo"
     schedule:
       interval: "daily"
-    target-branch: "dev"
-    directory: "/"
-
-  - package-ecosystem: "cargo"
-    schedule:
-      interval: "daily"
-    target-branch: "release"
+    target-branch: "iroha2-dev"
     directory: "/"

--- a/.github/workflows/sync-branches.yaml
+++ b/.github/workflows/sync-branches.yaml
@@ -11,7 +11,7 @@ on:
   types: [closed]
 
 jobs:
-  merge_iroha2-dev_to_master:
+  merge_iroha2-dev_to_iroha2-stable:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
         uses: dorny/paths-filter@v2.10.2
         id: filter
         with:
-          base: master
+          base: iroha2-stable
           filters: |
             cargo:
               - 'Cargo.toml'
@@ -30,10 +30,10 @@ jobs:
         uses: vsoch/pull-request-action@1.0.19
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_BRANCH: "master"
+          PULL_REQUEST_BRANCH: "iroha2-stable"
           PULL_REQUEST_FROM_BRANCH: "iroha2-dev"
-          PULL_REQUEST_TITLE: "Merge master into iroha2-dev"
-          PULL_REQUEST_BODY: "**Automated pull request**<br><br><p>Synchronize a changes from iroha2-dev to master branches</p>"
+          PULL_REQUEST_TITLE: "Merge iroha2-dev into iroha2-stable"
+          PULL_REQUEST_BODY: "**Automated pull request**<br><br><p>Synchronize a changes from iroha2-dev to iroha2-stable branches</p>"
           PULL_REQUEST_ASSIGNEES: ${{ github.actor }}
           PULL_REQUEST_REVIEWERS: BAStos525
           PULL_REQUEST_TEAM_REVIEWERS: soramitsu/devops-team soramitsu/devops-support

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -4,7 +4,7 @@ name: load-rs::bump-dependencies
 #   but there is not an any established day to update them
 # This is a dispatch event workflow that triggered 
 #   from I2::Dev::Deploy workflow in Hyperledger repo,
-#   merge changes to iroha2-dev branch and create a PR to master
+#   merge changes to iroha2-dev branch and create a PR to iroha2-stable
 
 on:
    workflow_dispatch:
@@ -58,7 +58,7 @@ jobs:
           echo "response about the workflow end"
           sleep 10s
 
-  bump-load-rs-master:
+  bump-load-rs-iroha2-stable:
     needs: [merge-load-rs-iroha2-dev]
     runs-on: ubuntu-latest
     steps:
@@ -67,7 +67,7 @@ jobs:
         uses: vsoch/pull-request-action@1.0.19
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_REQUEST_BRANCH: "master"
+          PULL_REQUEST_BRANCH: "iroha2-stable"
           PULL_REQUEST_FROM_BRANCH: "iroha2-dev"
           PULL_REQUEST_TITLE: "Update iroha2 dependencies to ${{ needs.merge-load-rs-iroha2-dev.outputs.pr_title }}"
           PULL_REQUEST_BODY: "**Automated pull request**<br><br><p>Update iroha2 dependencies from <a href=${{ env.VERSION_URL }}>Hyperledger repository</a></p>"


### PR DESCRIPTION

# Task

- #27 

## Changes

1. Rename branch `master` to `iroha2-stable`

## Author

Signed-off-by: Shunkichi Sato <49983831+s8sato@users.noreply.github.com>