### PR TITLE
[feature] #49: Add a graceful shutdown to the deamon mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rand = "0.8.4"
 
   [dependencies.tokio]
   version = "1"
-  features = [ "macros", "rt-multi-thread" ]
+  features = [ "macros", "rt-multi-thread", "signal" ]
 
   [dependencies.hyper]
   version = "0.14"

--- a/src/value.rs
+++ b/src/value.rs
@@ -17,19 +17,21 @@ impl ValueWrapper {
 impl Distribution<ValueWrapper> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> ValueWrapper {
         let value = match rng.gen_range(0..=6) {
-            0 => Value::U32(rng.gen()),
-            1 => Value::U128(rng.gen()),
+            0 => Value::Numeric(NumericValue::U32(rng.gen())),
+            1 => Value::Numeric(NumericValue::U128(rng.gen())),
             2 => Value::Bool(rng.gen()),
             3 => Value::String(format!("hello{}", rng.gen::<usize>())),
             4 => Value::Name(
                 Name::from_str(format!("bob{}", rng.gen::<usize>()).as_str()).expect("Valid name"),
             ),
-            5 => Value::Fixed(Fixed::try_from(rng.gen::<f64>()).expect("Valid float num")),
+            5 => Value::Numeric(NumericValue::Fixed(
+                Fixed::try_from(rng.gen::<f64>()).expect("Valid float num"),
+            )),
             6 => {
                 let len = rng.gen_range(0..=10);
                 let mut vec = Vec::with_capacity(len);
                 for _ in 0..len {
-                    vec.push(Value::U32(rng.gen()));
+                    vec.push(Value::Numeric(NumericValue::U32(rng.gen())));
                 }
                 Value::Vec(vec)
             }


### PR DESCRIPTION
# Task

Closes #49 

## Changes

This pull request adds a graceful shutdown to the `daemon` mode. Compared to [#51](https://github.com/soramitsu/iroha2-longevity-load-rs/pull/51), this pull solves [that problem](https://github.com/soramitsu/iroha2-longevity-load-rs/pull/51/files#r1017686269). But we still have a problem with blocking transaction requests. I'm going to resolve it within [this issue](https://github.com/hyperledger/iroha/issues/2940).

## Author

Signed-off-by: name <name@soramitsu.co.jp>
